### PR TITLE
Fixed wrong intersections splitting

### DIFF
--- a/src/main/java/com/conveyal/osmlib/OSM.java
+++ b/src/main/java/com/conveyal/osmlib/OSM.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.stream.LongStream;
 
 /**
  * osm-lib representation of a subset of OpenStreetMap. One or more OSM files (e.g. PBF) can be loaded into this
@@ -200,16 +201,20 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
      * Functions finds nodes which appear in multiple ways
      *
      * First time node appears it is added in referencedNodes and if it appears again it is intersection
+     *
+     * It also skips duplicate nodes in one way. If duplicate nodes aren't skipped there are a lot
+     * of zero length edges because OSM ways have sometimes duplicate nodes.
      * @param way
      */
-    private void findIntersectionNodes(Way way) {
-        for (long nodeId : way.nodes) {
-            if (referencedNodes.contains(nodeId)) {
-                intersectionNodes.add(nodeId);
-            } else {
-                referencedNodes.add(nodeId);
+    void findIntersectionNodes(Way way) {
+        LongStream.of(way.nodes).distinct().forEach(nodeId -> {
+                if (referencedNodes.contains(nodeId)) {
+                    intersectionNodes.add(nodeId);
+                } else {
+                    referencedNodes.add(nodeId);
+                }
             }
-        }
+        );
     }
 
     public void readFromUrl(String urlString) {

--- a/src/main/java/com/conveyal/osmlib/OSM.java
+++ b/src/main/java/com/conveyal/osmlib/OSM.java
@@ -180,9 +180,7 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
                 // and without it edge creation is wrong (since edges aren't split in intersections)
                 // FIXME this takes two minutes on NL OSM. We should probably save the intersections in a MapDB table.
                 LOG.info("Detecting intersections...");
-                for (Way way : ways.values()) {
-                    findIntersectionNodes(way);
-                }
+                ways.values().forEach(this::findIntersectionNodes);
                 //referenceNodes isn't needed after intersectionNodes is built
                 referencedNodes = null;
                 LOG.info("Done detecting intersections.");

--- a/src/main/java/com/conveyal/osmlib/OSM.java
+++ b/src/main/java/com/conveyal/osmlib/OSM.java
@@ -181,13 +181,7 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
                 // FIXME this takes two minutes on NL OSM. We should probably save the intersections in a MapDB table.
                 LOG.info("Detecting intersections...");
                 for (Way way : ways.values()) {
-                    for (long nodeId : way.nodes) {
-                        if (referencedNodes.contains(nodeId)) {
-                            intersectionNodes.add(nodeId);
-                        } else {
-                            referencedNodes.add(nodeId);
-                        }
-                    }
+                    findIntersectionNodes(way);
                 }
                 //referenceNodes isn't needed after intersectionNodes is built
                 referencedNodes = null;
@@ -201,6 +195,22 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
             source.copyTo(this);
         } catch (Exception ex) {
             throw new RuntimeException("Error occurred while parsing OSM file " + filePath, ex);
+        }
+    }
+
+    /**
+     * Functions finds nodes which appear in multiple ways
+     *
+     * First time node appears it is added in referencedNodes and if it appears again it is intersection
+     * @param way
+     */
+    private void findIntersectionNodes(Way way) {
+        for (long nodeId : way.nodes) {
+            if (referencedNodes.contains(nodeId)) {
+                intersectionNodes.add(nodeId);
+            } else {
+                referencedNodes.add(nodeId);
+            }
         }
     }
 
@@ -351,13 +361,7 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
 
         // Optionally track which nodes are referenced by more than one way.
         if (intersectionDetection) {
-            for (long nodeId : way.nodes) {
-                if (referencedNodes.contains(nodeId)) {
-                    intersectionNodes.add(nodeId);
-                } else {
-                    referencedNodes.add(nodeId);
-                }
-            }
+            findIntersectionNodes(way);
         }
 
         // Insert the way into the tile-based spatial index according to its first node.

--- a/src/main/java/com/conveyal/osmlib/OSM.java
+++ b/src/main/java/com/conveyal/osmlib/OSM.java
@@ -202,19 +202,29 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
      *
      * First time node appears it is added in referencedNodes and if it appears again it is intersection
      *
-     * It also skips duplicate nodes in one way. If duplicate nodes aren't skipped there are a lot
+     * Function skips all ways shorter then 3 nodes since you can't split 2 node way more then it already is
+     *
+     * It also skips consecutive duplicate nodes in one way. If duplicate nodes aren't skipped there are a lot
      * of zero length edges because OSM ways have sometimes duplicate nodes.
      * @param way
      */
     void findIntersectionNodes(Way way) {
-        LongStream.of(way.nodes).distinct().forEach(nodeId -> {
+        if (way.nodes.length <= 2) {
+            return;
+        }
+        long prevNodeId = way.nodes[0];
+        for(int i=1; i < way.nodes.length; i++) {
+            long nodeId = way.nodes[i];
+            //This skips consecutive duplicate nodes
+            if (nodeId!=prevNodeId) {
                 if (referencedNodes.contains(nodeId)) {
                     intersectionNodes.add(nodeId);
                 } else {
                     referencedNodes.add(nodeId);
                 }
             }
-        );
+            prevNodeId = nodeId;
+        }
     }
 
     public void readFromUrl(String urlString) {

--- a/src/test/java/com/conveyal/osmlib/OSMTest.java
+++ b/src/test/java/com/conveyal/osmlib/OSMTest.java
@@ -7,10 +7,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.stream.LongStream;
 
 public class OSMTest extends TestCase {
+	private OSM osm;
+
+	public void setUp() throws Exception {
+		osm = new OSM("./src/test/resources/tmp");
+
+	}
+
 	public void testOSM(){
-		OSM osm = new OSM("./src/test/resources/tmp");
 		osm.readFromFile("./src/test/resources/bangor_maine.osm.pbf");
 		assertEquals( osm.nodes.size(), 35747 );
 		assertEquals( osm.ways.size(), 2976 );
@@ -31,7 +38,49 @@ public class OSMTest extends TestCase {
 			}
 		}
 	}
-	
+
+	public void testIntersectionNodes() throws Exception {
+		Way way1 = new Way();
+		way1.nodes = new long[] { 1, 55, 22, 13 };
+		osm.findIntersectionNodes(way1);
+
+		//No intersections currently
+		assertTrue(
+			LongStream.of(way1.nodes).allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+
+		//This way intersects with previous one in node 55
+		Way wayIntersectsWithWay1 = new Way();
+		wayIntersectsWithWay1.nodes = new long[] { 5, 88, 3, 18, 55 };
+		osm.findIntersectionNodes(wayIntersectsWithWay1);
+
+		long[] nonIntersections = new long[] { 5, 88, 3, 18 };
+
+		assertTrue(LongStream.of(nonIntersections)
+			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+		assertTrue(osm.intersectionNodes.contains(55));
+
+		//Node with duplicate nodes which shouldn't be counted as intersection
+		Way wayWithDuplicateNodes = new Way();
+		wayWithDuplicateNodes.nodes = new long[] { 8, 7, 7, 33, 15 };
+		nonIntersections = new long[] { 8, 7, 33, 15 };
+
+		osm.findIntersectionNodes(wayWithDuplicateNodes);
+
+		assertTrue(LongStream.of(nonIntersections)
+			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+
+		//Node with duplicate nodes which are actually an intersection
+		Way wayWithDuplicateNodesAndIntersection = new Way();
+		wayWithDuplicateNodesAndIntersection.nodes = new long[] { 2, 98, 3, 3 };
+		nonIntersections = new long[] { 2, 98 };
+		osm.findIntersectionNodes(wayWithDuplicateNodesAndIntersection);
+
+		assertTrue(LongStream.of(nonIntersections)
+			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+		assertTrue(osm.intersectionNodes.contains(3));
+
+	}
+
 	public void tearDown() throws IOException{
 		Files.delete( Paths.get("./src/test/resources/tmp") );
 		Files.delete( Paths.get("./src/test/resources/tmp.p") );

--- a/src/test/java/com/conveyal/osmlib/OSMTest.java
+++ b/src/test/java/com/conveyal/osmlib/OSMTest.java
@@ -79,6 +79,26 @@ public class OSMTest extends TestCase {
 			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
 		assertTrue(osm.intersectionNodes.contains(3));
 
+		//Way with duplicate non consecutive nodes are actually an self intersection (node 34 self intersects)
+		Way wayWithDuplicateNonConsecutiveNodesAndIntersection = new Way();
+		wayWithDuplicateNonConsecutiveNodesAndIntersection.nodes = new long[] { 50, 34, 105, 111, 34, 85 };
+		nonIntersections = new long[] { 50, 105, 111, 85 };
+		osm.findIntersectionNodes(wayWithDuplicateNonConsecutiveNodesAndIntersection);
+
+		assertTrue(LongStream.of(nonIntersections)
+			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+		assertTrue(osm.intersectionNodes.contains(34));
+
+		//Way with duplicate non consecutive nodes are actually an self intersection (node 134 self intersects)
+		wayWithDuplicateNonConsecutiveNodesAndIntersection = new Way();
+		wayWithDuplicateNonConsecutiveNodesAndIntersection.nodes = new long[] { 150, 134, 1105, 1111, 134};
+		nonIntersections = new long[] { 150, 1105, 1111};
+		osm.findIntersectionNodes(wayWithDuplicateNonConsecutiveNodesAndIntersection);
+
+		assertTrue(LongStream.of(nonIntersections)
+			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+		assertTrue(osm.intersectionNodes.contains(134));
+
 	}
 
 	public void tearDown() throws IOException{

--- a/src/test/java/com/conveyal/osmlib/OSMTest.java
+++ b/src/test/java/com/conveyal/osmlib/OSMTest.java
@@ -46,7 +46,7 @@ public class OSMTest extends TestCase {
 
 		//No intersections currently
 		assertTrue(
-			LongStream.of(way1.nodes).allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			LongStream.of(way1.nodes).noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 
 		//This way intersects with previous one in node 55
 		Way wayIntersectsWithWay1 = new Way();
@@ -56,10 +56,10 @@ public class OSMTest extends TestCase {
 		long[] nonIntersections = new long[] { 5, 88, 3, 18 };
 
 		assertTrue(LongStream.of(nonIntersections)
-			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			.noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 		assertTrue(osm.intersectionNodes.contains(55));
 
-		//Node with duplicate nodes which shouldn't be counted as intersection
+		//way with consecutive duplicate nodes which shouldn't be counted as intersection
 		Way wayWithDuplicateNodes = new Way();
 		wayWithDuplicateNodes.nodes = new long[] { 8, 7, 7, 33, 15 };
 		nonIntersections = new long[] { 8, 7, 33, 15 };
@@ -67,16 +67,16 @@ public class OSMTest extends TestCase {
 		osm.findIntersectionNodes(wayWithDuplicateNodes);
 
 		assertTrue(LongStream.of(nonIntersections)
-			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			.noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 
-		//Node with duplicate nodes which are actually an intersection
+		//Way with consecutive duplicate nodes which are actually an intersection with a different road
 		Way wayWithDuplicateNodesAndIntersection = new Way();
 		wayWithDuplicateNodesAndIntersection.nodes = new long[] { 2, 98, 3, 3 };
 		nonIntersections = new long[] { 2, 98 };
 		osm.findIntersectionNodes(wayWithDuplicateNodesAndIntersection);
 
 		assertTrue(LongStream.of(nonIntersections)
-			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			.noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 		assertTrue(osm.intersectionNodes.contains(3));
 
 		//Way with duplicate non consecutive nodes are actually an self intersection (node 34 self intersects)
@@ -86,7 +86,7 @@ public class OSMTest extends TestCase {
 		osm.findIntersectionNodes(wayWithDuplicateNonConsecutiveNodesAndIntersection);
 
 		assertTrue(LongStream.of(nonIntersections)
-			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			.noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 		assertTrue(osm.intersectionNodes.contains(34));
 
 		//Way with duplicate non consecutive nodes are actually an self intersection (node 134 self intersects)
@@ -96,7 +96,7 @@ public class OSMTest extends TestCase {
 		osm.findIntersectionNodes(wayWithDuplicateNonConsecutiveNodesAndIntersection);
 
 		assertTrue(LongStream.of(nonIntersections)
-			.allMatch(nodeid -> !osm.intersectionNodes.contains(nodeid)));
+			.noneMatch(nodeid -> osm.intersectionNodes.contains(nodeid)));
 		assertTrue(osm.intersectionNodes.contains(134));
 
 	}


### PR DESCRIPTION
I noticed when I was working on angles that there are some edges with 0 length. Most of those are because ways have duplicate nodeids. Same node ID appears twice one after another seems to be problem in OSM itself. In OTP there is also check for duplicate nodeids so I added one to osm-lib which fixes the problem with most 0-length edges.

Also added tests.
