### PR TITLE
Roaring bitmaps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     </dependency>
     <dependency>
       <groupId>org.roaringbitmap</groupId>
-      <artifactId>roaringbitmap</artifactId>
+      <artifactId>RoaringBitmap</artifactId>
       <version>0.6.43</version>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -123,5 +123,10 @@
       <artifactId>aws-java-sdk-s3</artifactId>
       <version>1.11.18</version>
     </dependency>
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>roaringbitmap</artifactId>
+      <version>0.6.43</version>
+    </dependency>
   </dependencies>
 </project>

--- a/src/main/java/com/conveyal/osmlib/NodeTracker.java
+++ b/src/main/java/com/conveyal/osmlib/NodeTracker.java
@@ -1,83 +1,77 @@
 package com.conveyal.osmlib;
 
 import com.google.common.collect.Maps;
+import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /** 
  * A sparse bit set capable of handling 64-bit int indexes (like OSM IDs).
- * Each block is 64 64-bit longs. At 512 bytes long, it tracks 4096 IDs.
  * Node numbers in OSM tend to be contiguous so maybe the blocks should be bigger.
- * Disabled debug statements have no measurable effect on speed (verified).
  *
  * MapDB TreeSets are much faster than MapDB HashSets, but in-memory NodeTrackers are
  * much faster than MapDB TreeSets.
+ *
+ * To save space, this uses RoaringBitmaps. RoaringBitmaps currently only support 32 bit keys
+ * so we use multiple RoaringBitmaps containing the low 32 bits, stored in a map from the high
+ * 32 bits to a roaringbitmap. Since the OSM IDs are concentrated towards the bottom of the long
+ * space (i.e. they only need, so far, one more than an int provides), only a few blocks are used.
  */
 public class NodeTracker {
-
     private static final Logger LOG = LoggerFactory.getLogger(NodeTracker.class);
-    
-    /** Lowest 6 bits, index into a single 64-bit long int. */
-    private static final long LOW_MASK = 0x3F; 
-    private static final int LOW_SHIFT = 6;
-    
-    /** Lowest 12 bits, bit position within block. */
-    private static final long MID_MASK = 0xFFF;
-    
-    /** Highest 52 bits, the key for the block. */
-    private static final long BLOCK_MASK = ~MID_MASK;
-    
-    /** Each block is 64 64-bit longs. */ 
-    private Map<Long, long[]> blocks = Maps.newHashMap();
 
-    private int index(long x) {
-        return (int)((x & MID_MASK) >> LOW_SHIFT);
-    }
+    private Map<Integer, RoaringBitmap> blocks = new HashMap<>();
 
-    private int bit(long x) {
-        return (int)(x & LOW_MASK);
-    }
-    
-    /** 
-     * The create parameter allows us to examine a block for a set bit 
-     * without creating an empty block as a side effect.
-     */
-    private long[] block(long x, boolean create) {
-        long key = x & BLOCK_MASK;
-        long[] block = blocks.get(key);
-        if (block == null && create) {
-            block = new long[64];
-            blocks.put(key, block);
-            LOG.debug("Number of blocks is now {}, total {} MiB", blocks.size(), blocks.size() * 64 * 8 / 1024.0 / 1024.0);
-        }
-        LOG.debug("   block {}", key);
-        return block;
-    }
-    
     public void add(long x) {
-        LOG.debug("set node {}: index {} bit {}", x, index(x), bit(x));
-        block(x, true)[index(x)] |= (1L << bit(x));
+        int high = highIndex(x);
+        int low = lowIndex(x);
+
+        if (!blocks.containsKey(high)) {
+            blocks.put(high, new RoaringBitmap());
+            LOG.debug("New block, {} blocks now", blocks.size());
+        }
+        blocks.get(high).add(low);
     }
 
     public boolean contains(long x) {
-        LOG.debug("get node {}: index {} bit {}", x, index(x), bit(x));
-        long[] block = block(x, false);
-        if (block == null) return false; 
-        return (block[index(x)] & (1L << bit(x))) != 0;
+        int high = highIndex(x);
+        RoaringBitmap block = blocks.get(high);
+        if (block != null) {
+            int low = lowIndex(x);
+            return block.contains(low);
+        } else {
+            return false; // block not found
+        }
+    }
+
+    public int cardinality () {
+        // cardinality is the sum of the cardinality of all member bitmaps
+        return blocks.values().stream()
+                .mapToInt(RoaringBitmap::getCardinality)
+                .sum();
+    }
+
+    private static int highIndex (long key) {
+        return (int) (key >> 32);
+    }
+
+    private static int lowIndex (long key) {
+        return (int) key;
     }
 
     public static NodeTracker acceptEverything() {
         return new NodeTracker() {
-            @Override 
+            @Override
             public boolean contains(long x) {
                 return true;
             }
         };
     }
-    
 }
+
 
 // Scan through nodes, marking those that are within the bbox.
 // Then load ways, keeping only those that contain at least one marked node.

--- a/src/main/java/com/conveyal/osmlib/OSM.java
+++ b/src/main/java/com/conveyal/osmlib/OSM.java
@@ -181,6 +181,7 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
                 // FIXME this takes two minutes on NL OSM. We should probably save the intersections in a MapDB table.
                 LOG.info("Detecting intersections...");
                 for (Way way : ways.values()) {
+                    if (way.hasTag("building")) continue;
                     for (long nodeId : way.nodes) {
                         if (referencedNodes.contains(nodeId)) {
                             intersectionNodes.add(nodeId);
@@ -350,7 +351,7 @@ public class OSM implements OSMEntitySource, OSMEntitySink {
         this.ways.put(id, way);
 
         // Optionally track which nodes are referenced by more than one way.
-        if (intersectionDetection) {
+        if (intersectionDetection && !way.hasTag("building")) {
             for (long nodeId : way.nodes) {
                 if (referencedNodes.contains(nodeId)) {
                     intersectionNodes.add(nodeId);

--- a/src/test/java/com/conveyal/osmlib/NodeTrackerTest.java
+++ b/src/test/java/com/conveyal/osmlib/NodeTrackerTest.java
@@ -14,21 +14,18 @@ public class NodeTrackerTest extends TestCase {
     public void testAgainstSet() {
         final int N = 1000;
         // Set N numbers in each of four different ranges.
+        Set<Long> numbers = Sets.newHashSet();
+        NodeTracker tracker = new NodeTracker();
         for (long lo : new long[] {1L << 6, 1L << 16, 1L << 34, 1L << 50} ) {
             // Simultaneously set up a basic Set<Long> that will serve as a reference
             // and a NodeTracker that we want to test.
-            Set<Long> numbers = Sets.newHashSet();
-            NodeTracker tracker = new NodeTracker();
             long hi = 0L;
-            int count = 0;
             for (int i = 0; i < 1000; i++) {
                 long n = i * i + lo;
                 numbers.add(n);
                 tracker.add(n);
                 hi = n;
-                count++;
             }
-            assertTrue(numbers.size() == count);
             // Check that the two set implementations match for every value in the range (including unset ones).
             // Note that a Set<Long> containing 0L returns false for contains((int)0).
             for (long i = lo; i < hi; i++) {
@@ -43,6 +40,8 @@ public class NodeTrackerTest extends TestCase {
                     assertFalse(tracker.contains(i));
                 }
             }
+
+            assertEquals(numbers.size(), tracker.cardinality());
         }
     }
 }


### PR DESCRIPTION
Fix #32 by using compressed bitmaps so we don't run out of memory when loading large OSM data.